### PR TITLE
Make KV bindings work in local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ tsconfig.tsbuildinfo
 # Cloudflare
 wrangler.dev.toml
 .dev.vars
+wrangler-local-state

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "license": "MIT",
   "scripts": {
-    "dev": "wrangler dev --config wrangler.dev.toml --env dev --local",
+    "dev": "wrangler dev --config wrangler.dev.toml --env dev --local --experimental-enable-local-persistence",
     "lint": "eslint .",
     "typecheck": "tsc -b"
   },


### PR DESCRIPTION
If we use `wrangler dev` with `--local` flag, `wrangler` will not use the remote KV data store set in `wrangler.dev.toml`. Instead, `wrangler` will use the **in-memory** KV data store, and all KV data will be gone after the `wrangler dev` process stops.

To make KV data persist locally, we need to add `--experimental-enable-local-persistence` to the `wrangler dev` command.

However, even if we use the KV locally, we still need to set the KV bindings inside the `wrangler.dev.toml` as README suggests with the id and perview_id of the same namespace id of the preview KV namespace (created with the --preview flag) which wil not be touched anyway if we use the `--local` flag in `wrangler dev`.
